### PR TITLE
sort lines by draw order from csv

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -24,8 +24,8 @@ export default function Page() {
       const ids = (e as CustomEvent).detail as string[];
       setActiveLines(new Set(ids));
     };
-    window.addEventListener('page:update-lines', onUpdate as any);
-    return () => window.removeEventListener('page:update-lines', onUpdate as any);
+    window.addEventListener('page:update-lines', onUpdate as EventListener);
+    return () => window.removeEventListener('page:update-lines', onUpdate as EventListener);
   }, []);
 
   if (!bundle) {
@@ -43,11 +43,15 @@ export default function Page() {
         activeLines={activeLines}
         onToggle={(id) => {
           const next = new Set(activeLines);
-          next.has(id) ? next.delete(id) : next.add(id);
+          if (next.has(id)) {
+            next.delete(id);
+          } else {
+            next.add(id);
+          }
           setActiveLines(next);
         }}
       />
-      <MetroCanvas bundle={bundle} activeLines={activeLines} corridors={bundle.corridors} />
+      <MetroCanvas bundle={bundle} activeLines={activeLines} />
     </>
   );
 }

--- a/src/components/Legend.tsx
+++ b/src/components/Legend.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { Corridor, DataBundle } from '@/lib/types';
+import { DataBundle } from '@/lib/types';
 
 type Props = {
   bundle: DataBundle;

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -41,6 +41,7 @@ function toCorridors(rows: Record<string, string>[]): Corridor[] {
     corridor_id: r.corridor_id,
     name: r.name,
     color: r.color,
+    order: Number(r.order) || 0,
   }));
 }
 
@@ -51,6 +52,7 @@ function toLines(rows: Record<string, string>[]): Line[] {
     name: r.name,
     color: r.color,
     style: (r.style as Line['style']) || 'solid',
+    draw_order: Number(r.draw_order) || 0,
   }));
 }
 
@@ -70,10 +72,10 @@ export async function loadData(): Promise<DataBundle> {
     fetchText('/data/line_paths.csv'),
   ]);
 
-  return {
-    cities: toCities(parseCSV(citiesTxt)),
-    corridors: toCorridors(parseCSV(corridorsTxt)),
-    lines: toLines(parseCSV(linesTxt)),
-    linePaths: toLinePaths(parseCSV(pathsTxt)),
-  };
+  const cities = toCities(parseCSV(citiesTxt));
+  const corridors = toCorridors(parseCSV(corridorsTxt)).sort((a, b) => a.order - b.order);
+  const lines = toLines(parseCSV(linesTxt)).sort((a, b) => a.draw_order - b.draw_order);
+  const linePaths = toLinePaths(parseCSV(pathsTxt));
+
+  return { cities, corridors, lines, linePaths };
 }

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -1,4 +1,4 @@
-import type { City, Corridor, DataBundle, Line, LinePath } from './types';
+import type { City, DataBundle, Line } from './types';
 
 export type Edge = {
   a: string;       // city_id
@@ -40,12 +40,13 @@ export function lineToEdges(line: Line, bundle: DataBundle): Edge[] {
 }
 
 export function buildAllEdges(bundle: DataBundle) {
-  return bundle.lines.flatMap((l) => lineToEdges(l, bundle));
+  const lines = [...bundle.lines].sort((a, b) => (a.draw_order ?? 0) - (b.draw_order ?? 0));
+  return lines.flatMap((l) => lineToEdges(l, bundle));
 }
 
 export function buildAllEdgesSafe(bundle?: DataBundle | null) {
   if (!bundle) return [];
-  return bundle.lines.flatMap((l) => lineToEdges(l, bundle));
+  return buildAllEdges(bundle);
 }
 
 // очень простой раскладчик подписей (без коллизий, но с оффсетами)

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -9,6 +9,7 @@ export type Corridor = {
   corridor_id: string;
   name: string;
   color: string; // HEX
+  order?: number; // для сортировки в легенде
 };
 
 export type Line = {
@@ -17,6 +18,7 @@ export type Line = {
   name: string;
   color: string; // HEX
   style?: 'solid' | 'dashed' | 'dotted';
+  draw_order?: number; // порядок отрисовки
 };
 
 export type LinePath = {


### PR DESCRIPTION
## Summary
- parse corridor order and line draw_order from CSV
- sort corridors, lines and edges using these fields
- clean up types and event listeners to satisfy lint

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b918795660832180d3b757dff84285