### PR TITLE
Display route summary for selected path

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react';
 import Legend from '@/components/Legend';
 import MetroCanvas from '@/components/MetroCanvas';
 import RouteSelector from '@/components/RouteSelector';
+import RouteSummary from '@/components/RouteSummary';
 import { DataBundle } from '@/lib/types';
 import { loadData } from '@/lib/csv';
 import type { RouteSegment } from '@/lib/router';
@@ -56,6 +57,7 @@ export default function Page() {
       />
       <RouteSelector bundle={bundle} onRoute={setCurrentRoute} />
       <MetroCanvas bundle={bundle} activeLines={activeLines} currentRoute={currentRoute} />
+      <RouteSummary bundle={bundle} route={currentRoute} />
     </>
   );
 }

--- a/src/components/RouteSummary.tsx
+++ b/src/components/RouteSummary.tsx
@@ -1,0 +1,68 @@
+'use client';
+import { useMemo } from 'react';
+import type { RouteSegment } from '@/lib/router';
+import type { DataBundle } from '@/lib/types';
+
+type Props = {
+  route: RouteSegment[];
+  bundle: DataBundle;
+};
+
+export default function RouteSummary({ route, bundle }: Props) {
+  const cityIndex = useMemo(() => {
+    const idx: Record<string, string> = {};
+    for (const c of bundle.cities) idx[c.city_id] = c.label || c.city_id;
+    return idx;
+  }, [bundle.cities]);
+
+  if (route.length === 0) return null;
+
+  const cities: string[] = [];
+  cities.push(cityIndex[route[0].from] ?? route[0].from);
+  for (const seg of route) {
+    const name = cityIndex[seg.to] ?? seg.to;
+    if (cities[cities.length - 1] !== name) cities.push(name);
+  }
+
+  const lines: string[] = [];
+  let prevLine: string | null = null;
+  for (const seg of route) {
+    if (seg.transfer) continue;
+    if (seg.line.line_id !== prevLine) {
+      lines.push(seg.line.name);
+      prevLine = seg.line.line_id;
+    }
+  }
+
+  const transfers = route.filter((s) => s.transfer).length;
+  const legs = route.filter((s) => !s.transfer).length;
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        right: 12,
+        bottom: 12,
+        padding: 12,
+        background: '#fff',
+        border: '1px solid #e5e7eb',
+        borderRadius: 8,
+        zIndex: 4,
+        fontFamily: 'Inter, system-ui, sans-serif',
+        maxWidth: 320,
+      }}
+    >
+      <div style={{ fontWeight: 600, marginBottom: 8 }}>Сводка маршрута</div>
+      <div style={{ fontSize: 13, marginBottom: 6 }}>
+        Города: {cities.join(' → ')}
+      </div>
+      <div style={{ fontSize: 13, marginBottom: 6 }}>
+        Линии: {lines.join(', ')}
+      </div>
+      <div style={{ fontSize: 13 }}>
+        Пересадок: {transfers}, плеч: {legs}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- implement RouteSummary component showing city sequence, lines, transfer & leg counts
- render RouteSummary in page overlay beside map

## Testing
- `npm test` (missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c1dbabbcac83219ee76c8b0d129a40