### PR TITLE
Build route catalog in worker

### DIFF
--- a/public/data/cities_grid.csv
+++ b/public/data/cities_grid.csv
@@ -1,0 +1,4 @@
+from,to
+A,B
+B,C
+B,D

--- a/public/data/drivers.csv
+++ b/public/data/drivers.csv
@@ -1,0 +1,3 @@
+driver_id,route
+d1,A;B;C
+d2,B;D

--- a/src/lib/load-route-catalog.ts
+++ b/src/lib/load-route-catalog.ts
@@ -1,0 +1,16 @@
+import type { RouteCatalog } from './types';
+
+export function loadRouteCatalog(): Promise<RouteCatalog> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(new URL('./route-catalog-worker.ts', import.meta.url));
+    worker.onmessage = (e) => {
+      resolve(e.data as RouteCatalog);
+      worker.terminate();
+    };
+    worker.onerror = (e) => {
+      reject(e);
+      worker.terminate();
+    };
+    worker.postMessage(null);
+  });
+}

--- a/src/lib/route-catalog-worker.ts
+++ b/src/lib/route-catalog-worker.ts
@@ -1,0 +1,75 @@
+/* eslint-env worker */
+import Papa from 'papaparse';
+import { get, set } from 'idb-keyval';
+import type { Driver, RouteCatalog } from './types';
+
+const DRIVERS_URL = '/data/drivers.csv';
+const GRID_URL = '/data/cities_grid.csv';
+const HASH_KEY = 'routeCatalogHash';
+const CATALOG_KEY = 'routeCatalog';
+
+async function hashStrings(...texts: string[]): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(texts.join('|'));
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  return Array.from(new Uint8Array(hashBuffer))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+self.addEventListener('message', async () => {
+  const [driversCsv, gridCsv] = await Promise.all([
+    fetch(DRIVERS_URL).then((r) => r.text()),
+    fetch(GRID_URL).then((r) => r.text()),
+  ]);
+
+  const currentHash = await hashStrings(driversCsv, gridCsv);
+  const cachedHash = await get<string>(HASH_KEY);
+  const cachedCatalog = await get<RouteCatalog>(CATALOG_KEY);
+
+  if (cachedHash === currentHash && cachedCatalog) {
+    postMessage(cachedCatalog);
+    return;
+  }
+
+  type RawRecord = Record<string, string>;
+  const driversRows = Papa.parse<RawRecord>(driversCsv, { header: true }).data;
+  const gridRows = Papa.parse<RawRecord>(gridCsv, { header: true }).data;
+
+  const drivers: Driver[] = driversRows
+    .filter((r) => r.driver_id)
+    .map((r) => ({
+      id: String(r.driver_id),
+      path: String(r.route || '')
+        .split(';')
+        .map((c: string) => c.trim())
+        .filter(Boolean),
+    }));
+
+  const edgeToDrivers: Record<string, string[]> = {};
+  for (const driver of drivers) {
+    for (let i = 0; i < driver.path.length - 1; i++) {
+      const from = driver.path[i];
+      const to = driver.path[i + 1];
+      const key = `${from}-${to}`;
+      (edgeToDrivers[key] ||= []).push(driver.id);
+    }
+  }
+
+  const adj: Record<string, string[]> = {};
+  for (const row of gridRows) {
+    const from = String(row.from || '').trim();
+    const to = String(row.to || '').trim();
+    if (!from || !to) continue;
+    (adj[from] ||= []).push(to);
+  }
+
+  const catalog: RouteCatalog = { drivers, edgeToDrivers, adj };
+
+  await set(HASH_KEY, currentHash);
+  await set(CATALOG_KEY, catalog);
+
+  postMessage(catalog);
+});
+
+export {};

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,3 +40,14 @@ export type DataBundle = {
   linePaths: LinePath[];
 };
 
+
+export interface Driver {
+  id: string;
+  path: string[];
+}
+
+export interface RouteCatalog {
+  drivers: Driver[];
+  edgeToDrivers: Record<string, string[]>;
+  adj: Record<string, string[]>;
+}


### PR DESCRIPTION
## Summary
- Define Driver and RouteCatalog types
- Add worker to parse driver and grid CSVs via PapaParse and cache results in IndexedDB
- Provide helper to load catalog and sample CSV data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c53d8ee05083218a2706e076f4674f