### PR TITLE
feat: add floating drawer toggle on map

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from 'react';
 import Legend from '@/components/Legend';
 import MetroCanvas from '@/components/MetroCanvas';
+import FabDrawer from '@/components/FabDrawer';
 import { DataBundle } from '@/lib/types';
 import { loadData } from '@/lib/csv';
 
@@ -53,6 +54,9 @@ export default function Page() {
         }}
       />
       <MetroCanvas bundle={bundle} activeLines={activeLines} />
+      <FabDrawer>
+        <div className="p-4">Панель</div>
+      </FabDrawer>
     </>
   );
 }

--- a/src/components/FabDrawer.tsx
+++ b/src/components/FabDrawer.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useState } from 'react';
+import { Menu, X } from 'lucide-react';
+import { Drawer, DrawerContent } from './ui/drawer';
+
+export default function FabDrawer({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button
+        onClick={() => setOpen(o => !o)}
+        className="fixed top-4 right-4 z-50 rounded-full bg-blue-600 p-3 text-white shadow-lg transition-colors hover:bg-blue-700"
+        aria-label="Toggle panel"
+      >
+        {open ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+      </button>
+      <Drawer open={open} onOpenChange={setOpen}>
+        <DrawerContent>{children}</DrawerContent>
+      </Drawer>
+    </>
+  );
+}

--- a/src/components/ui/drawer.tsx
+++ b/src/components/ui/drawer.tsx
@@ -8,11 +8,14 @@ export interface DrawerProps {
   children: React.ReactNode;
 }
 
-export function Drawer({ open, children }: DrawerProps) {
+export function Drawer({ open, onOpenChange, children }: DrawerProps) {
   if (!open) return null;
   return createPortal(
     <div className="fixed inset-0 z-40 pointer-events-none">
-      <div className="absolute inset-0 bg-black/40" />
+      <div
+        className="absolute inset-0 bg-black/40"
+        onClick={() => onOpenChange?.(false)}
+      />
       <div className="absolute inset-0 flex justify-end">
         <div className="pointer-events-auto h-full w-full max-w-md overflow-y-auto rounded-l-xl bg-white p-4 shadow-lg dark:bg-gray-800 dark:text-white">
           {children}


### PR DESCRIPTION
## Summary
- add Drawer component integration with floating action button on map
- allow Drawer to close when clicking the backdrop
- wire FAB + Drawer into main page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c53e5994b08321be438cddcbd8b93c