### PR TITLE
Add route search UI with combobox autocomplete and virtualized results

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,12 +3,17 @@ import { useEffect, useState } from 'react';
 import Legend from '@/components/Legend';
 import MetroCanvas from '@/components/MetroCanvas';
 import FabDrawer from '@/components/FabDrawer';
+import RouteSelector from '@/components/RouteSelector';
+import RouteResultList from '@/components/RouteResultList';
 import { DataBundle } from '@/lib/types';
 import { loadData } from '@/lib/csv';
+import type { RouteSegment } from '@/lib/router';
 
 export default function Page() {
   const [bundle, setBundle] = useState<DataBundle | null>(null);
   const [activeLines, setActiveLines] = useState<Set<string>>(new Set());
+  const [routes, setRoutes] = useState<RouteSegment[][]>([]);
+  const [selected, setSelected] = useState<number | null>(null);
 
   useEffect(() => {
     loadData()
@@ -53,7 +58,26 @@ export default function Page() {
           });
         }}
       />
-      <MetroCanvas bundle={bundle} activeLines={activeLines} />
+      <MetroCanvas
+        bundle={bundle}
+        activeLines={activeLines}
+        currentRoute={selected != null ? routes[selected] : []}
+      />
+      <RouteSelector
+        bundle={bundle}
+        onRoute={(r) => {
+          setRoutes(r);
+          setSelected(r.length ? 0 : null);
+        }}
+      />
+      {routes.length > 0 && (
+        <RouteResultList
+          routes={routes}
+          bundle={bundle}
+          selected={selected}
+          onSelect={setSelected}
+        />
+      )}
       <FabDrawer>
         <div className="p-4">Панель</div>
       </FabDrawer>

--- a/src/components/RouteResultList.tsx
+++ b/src/components/RouteResultList.tsx
@@ -1,5 +1,6 @@
 'use client';
-import { useMemo } from 'react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+import { useVirtualizer } from '@tanstack/react-virtual';
 import type { DataBundle } from '@/lib/types';
 import type { RouteSegment } from '@/lib/router';
 import { distance } from '@/lib/geometry';
@@ -18,18 +19,21 @@ export default function RouteResultList({ routes, bundle, selected, onSelect }: 
     return m;
   }, [bundle.cities]);
 
-  const routeDistance = (route: RouteSegment[]) => {
-    let d = 0;
-    for (const seg of route) {
-      if (seg.transfer) continue;
-      const a = cityIndex[seg.from];
-      const b = cityIndex[seg.to];
-      if (a && b) d += distance(a, b);
-    }
-    return Math.round(d);
-  };
+  const routeDistance = useCallback(
+    (route: RouteSegment[]) => {
+      let d = 0;
+      for (const seg of route) {
+        if (seg.transfer) continue;
+        const a = cityIndex[seg.from];
+        const b = cityIndex[seg.to];
+        if (a && b) d += distance(a, b);
+      }
+      return Math.round(d);
+    },
+    [cityIndex]
+  );
 
-  const routeLines = (route: RouteSegment[]) => {
+  const routeLines = useCallback((route: RouteSegment[]) => {
     const out: RouteSegment['line'][] = [];
     let prev: string | null = null;
     for (const seg of route) {
@@ -40,7 +44,41 @@ export default function RouteResultList({ routes, bundle, selected, onSelect }: 
       }
     }
     return out;
-  };
+  }, []);
+
+  const [sortBy, setSortBy] = useState<'distance' | 'transfers'>('distance');
+  const [corridor, setCorridor] = useState<string>('all');
+
+  const items = useMemo(() => {
+    return routes.map((r, idx) => {
+      const lines = routeLines(r);
+      const dist = routeDistance(r);
+      const transfers = r.filter((s) => s.transfer).length;
+      const corridors = new Set(lines.map((l) => l.corridor_id));
+      const start = cityIndex[r[0].from]?.label || r[0].from;
+      const end = cityIndex[r[r.length - 1].to]?.label || r[r.length - 1].to;
+      return { idx, route: r, lines, dist, transfers, corridors, start, end };
+    });
+  }, [routes, cityIndex, routeLines, routeDistance]);
+
+  const filtered = useMemo(() => {
+    if (corridor === 'all') return items;
+    return items.filter((i) => i.corridors.has(corridor));
+  }, [items, corridor]);
+
+  const sorted = useMemo(() => {
+    return [...filtered].sort((a, b) =>
+      sortBy === 'distance' ? a.dist - b.dist : a.transfers - b.transfers
+    );
+  }, [filtered, sortBy]);
+
+  const parentRef = useRef<HTMLDivElement>(null);
+  const rowVirtualizer = useVirtualizer({
+    count: sorted.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => 92,
+    overscan: 5,
+  });
 
   if (!routes.length) return null;
 
@@ -64,74 +102,122 @@ export default function RouteResultList({ routes, bundle, selected, onSelect }: 
         color: 'var(--text)',
       }}
     >
-      {routes.map((r, idx) => {
-        const lines = routeLines(r);
-        const dist = routeDistance(r);
-        const start = cityIndex[r[0].from]?.label || r[0].from;
-        const end = cityIndex[r[r.length - 1].to]?.label || r[r.length - 1].to;
-        return (
-          <button
-            key={idx}
-            onClick={() => onSelect(idx)}
-            style={{
-              textAlign: 'left',
-              padding: '10px 12px',
-              borderRadius: 12,
-              border: selected === idx ? '2px solid #E4002B' : '1px solid var(--btn-border)',
-              background: 'var(--frame-bg)',
-              cursor: 'pointer',
-              display: 'flex',
-              flexDirection: 'column',
-              gap: 6,
-            }}
-          >
-            <div
-              style={{
-                fontWeight: 600,
-                fontSize: 14,
-                display: 'flex',
-                alignItems: 'center',
-                gap: 4,
-              }}
-            >
-              <span style={{ color: '#6b7280' }}>{idx + 1}.</span>
-              {start} → {end}
-            </div>
-            <div
-              style={{
-                display: 'flex',
-                alignItems: 'center',
-                gap: 4,
-                flexWrap: 'wrap',
-                fontSize: 12,
-              }}
-            >
-              {lines.map((l, j) => (
-                <span
-                  key={l.line_id}
-                  style={{ display: 'flex', alignItems: 'center', gap: 4 }}
+      <div style={{ display: 'flex', gap: 8 }}>
+        <select
+          value={sortBy}
+          onChange={(e) => setSortBy(e.target.value as 'distance' | 'transfers')}
+          className="rounded border px-2 py-1 text-sm"
+        >
+          <option value="distance">По расстоянию</option>
+          <option value="transfers">По пересадкам</option>
+        </select>
+        <select
+          value={corridor}
+          onChange={(e) => setCorridor(e.target.value)}
+          className="rounded border px-2 py-1 text-sm"
+        >
+          <option value="all">Все коридоры</option>
+          {bundle.corridors.map((c) => (
+            <option key={c.corridor_id} value={c.corridor_id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div ref={parentRef} style={{ overflowY: 'auto', maxHeight: 300 }}>
+        <div
+          style={{
+            height: rowVirtualizer.getTotalSize(),
+            position: 'relative',
+          }}
+        >
+          {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+            const item = sorted[virtualRow.index];
+            return (
+              <div
+                key={virtualRow.key}
+                ref={rowVirtualizer.measureElement}
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  transform: `translateY(${virtualRow.start}px)`,
+                  paddingBottom: 8,
+                }}
+              >
+                <button
+                  onClick={() => onSelect(item.idx)}
+                  onMouseEnter={() => onSelect(item.idx)}
+                  className="w-full text-left rounded-xl hover:bg-gray-100 flex flex-col gap-1.5"
+                  style={{
+                    padding: '10px 12px',
+                    border:
+                      selected === item.idx
+                        ? '2px solid #E4002B'
+                        : '1px solid var(--btn-border)',
+                    background: 'var(--frame-bg)',
+                    cursor: 'pointer',
+                  }}
                 >
-                  <span
+                  <div
                     style={{
-                      background: l.color,
-                      color: '#fff',
-                      padding: '2px 6px',
-                      borderRadius: 4,
+                      fontWeight: 600,
+                      fontSize: 14,
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 4,
+                    }}
+                  >
+                    <span style={{ color: '#6b7280' }}>
+                      {virtualRow.index + 1}.
+                    </span>
+                    {item.start} → {item.end}
+                  </div>
+                  <div
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 4,
+                      flexWrap: 'wrap',
                       fontSize: 12,
                     }}
                   >
-                    {l.name}
-                  </span>
-                  {j < lines.length - 1 && (
-                    <span style={{ color: '#6b7280' }}>→</span>
-                  )}
-                </span>
-              ))}
-              <span style={{ marginLeft: 'auto', color: '#6b7280' }}>{dist} км</span>
-            </div>
-          </button>
-        );
-      })}
+                    {item.lines.map((l, j) => (
+                      <span
+                        key={l.line_id}
+                        style={{
+                          display: 'flex',
+                          alignItems: 'center',
+                          gap: 4,
+                        }}
+                      >
+                        <span
+                          style={{
+                            background: l.color,
+                            color: '#fff',
+                            padding: '2px 6px',
+                            borderRadius: 4,
+                            fontSize: 12,
+                          }}
+                        >
+                          {l.name}
+                        </span>
+                        {j < item.lines.length - 1 && (
+                          <span style={{ color: '#6b7280' }}>→</span>
+                        )}
+                      </span>
+                    ))}
+                    <span style={{ marginLeft: 'auto', color: '#6b7280' }}>
+                      {item.dist} км
+                    </span>
+                  </div>
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/components/RouteSelector.tsx
+++ b/src/components/RouteSelector.tsx
@@ -1,8 +1,9 @@
 'use client';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { DataBundle } from '@/lib/types';
 import { findRoutes } from '@/lib/graph';
 import type { RouteSegment } from '@/lib/router';
+import { Combobox } from './ui/combobox';
 
 type Props = {
   bundle: DataBundle;
@@ -12,6 +13,15 @@ type Props = {
 export default function RouteSelector({ bundle, onRoute }: Props) {
   const [from, setFrom] = useState('');
   const [to, setTo] = useState('');
+
+  const options = useMemo(
+    () =>
+      bundle.cities.map((c) => ({
+        value: c.city_id,
+        label: c.label || c.city_id,
+      })),
+    [bundle.cities]
+  );
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -37,30 +47,22 @@ export default function RouteSelector({ bundle, onRoute }: Props) {
         fontFamily: 'Inter, system-ui, sans-serif',
       }}
     >
-      <select
-        value={from}
-        onChange={(e) => setFrom(e.target.value)}
-        style={{ padding: '4px 6px', border: '1px solid #d1d5db', borderRadius: 4 }}
-      >
-        <option value="">Откуда</option>
-        {bundle.cities.map((c) => (
-          <option key={c.city_id} value={c.city_id}>
-            {c.label || c.city_id}
-          </option>
-        ))}
-      </select>
-      <select
-        value={to}
-        onChange={(e) => setTo(e.target.value)}
-        style={{ padding: '4px 6px', border: '1px solid #d1d5db', borderRadius: 4 }}
-      >
-        <option value="">Куда</option>
-        {bundle.cities.map((c) => (
-          <option key={c.city_id} value={c.city_id}>
-            {c.label || c.city_id}
-          </option>
-        ))}
-      </select>
+      <div style={{ width: 150 }}>
+        <Combobox
+          value={from}
+          onChange={setFrom}
+          options={options}
+          placeholder="Откуда"
+        />
+      </div>
+      <div style={{ width: 150 }}>
+        <Combobox
+          value={to}
+          onChange={setTo}
+          options={options}
+          placeholder="Куда"
+        />
+      </div>
       <button type="submit" className="map-btn" style={{ padding: '4px 8px' }}>
         Найти
       </button>

--- a/src/components/ui/combobox.tsx
+++ b/src/components/ui/combobox.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { cn } from '@/lib/utils';
 
 export interface ComboboxOption {
@@ -15,23 +15,33 @@ export interface ComboboxProps {
 
 export function Combobox({ value, onChange, options, placeholder }: ComboboxProps) {
   const [open, setOpen] = useState(false);
-  const selected = options.find((o) => o.value === value);
+  const [query, setQuery] = useState('');
+
+  useEffect(() => {
+    const selected = options.find((o) => o.value === value);
+    setQuery(selected ? selected.label : '');
+  }, [value, options]);
+
+  const filtered = options.filter((o) =>
+    o.label.toLowerCase().includes(query.toLowerCase())
+  );
 
   return (
     <div className="relative">
       <input
         className="w-full rounded border px-2 py-2 text-sm"
         placeholder={placeholder}
-        value={selected ? selected.label : ''}
+        value={query}
         onFocus={() => setOpen(true)}
         onChange={(e) => {
-          const match = options.find((o) => o.label === e.target.value);
-          if (match) onChange(match.value);
+          setQuery(e.target.value);
+          setOpen(true);
         }}
+        onBlur={() => setOpen(false)}
       />
-      {open && (
+      {open && filtered.length > 0 && (
         <ul className="absolute z-10 mt-1 max-h-60 w-full overflow-auto rounded-md border bg-white shadow">
-          {options.map((o) => (
+          {filtered.map((o) => (
             <li
               key={o.value}
               className={cn(
@@ -40,6 +50,7 @@ export function Combobox({ value, onChange, options, placeholder }: ComboboxProp
               )}
               onMouseDown={() => {
                 onChange(o.value);
+                setQuery(o.label);
                 setOpen(false);
               }}
             >


### PR DESCRIPTION
## Summary
- replace "Откуда/Куда" selectors with autocomplete combobox backed by city grid data
- add virtualized route result list with sorting and corridor filtering
- wire route search components into main page to show results on submit

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68c53fcf05d88321ac2959009575b583