### PR TITLE
Add multi-mode search and route pinning

### DIFF
--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -1,0 +1,136 @@
+'use client';
+import { DataBundle } from '@/lib/types';
+import type { RouteSegment } from '@/lib/router';
+import { distance } from '@/lib/geometry';
+import { useMemo } from 'react';
+
+export type SearchResults = {
+  exact: RouteSegment[][];
+  geo: RouteSegment[][];
+  bfs: RouteSegment[][];
+};
+
+export type SelectedRoute = { type: keyof SearchResults; idx: number } | null;
+
+type Props = {
+  results: SearchResults;
+  bundle: DataBundle;
+  selected: SelectedRoute;
+  onShow: (type: keyof SearchResults, idx: number) => void;
+  onPin: (type: keyof SearchResults, idx: number) => void;
+};
+
+function useCityIndex(bundle: DataBundle) {
+  return useMemo(() => {
+    const m: Record<string, { x: number; y: number; label?: string }> = {};
+    for (const c of bundle.cities) m[c.city_id] = c;
+    return m;
+  }, [bundle.cities]);
+}
+
+type Item = ReturnType<typeof buildItem>;
+
+function RouteCard({
+  item,
+  active,
+  onShow,
+  onPin,
+}: {
+  item: Item;
+  active: boolean;
+  onShow: () => void;
+  onPin: () => void;
+}) {
+  return (
+    <div
+      className="rounded-xl border p-2 mb-2"
+      style={{ borderColor: active ? '#E4002B' : 'var(--btn-border)' }}
+    >
+      <div className="text-sm font-semibold mb-1">
+        {item.start} → {item.end}
+      </div>
+      <div className="text-xs text-gray-600 mb-2 flex gap-2 flex-wrap">
+        <span>{item.dist} км</span>
+        <span>пересадок: {item.transfers}</span>
+      </div>
+      <div className="flex gap-2">
+        <button className="text-xs map-btn" onClick={onShow}>
+          Показать путь
+        </button>
+        <button className="text-xs map-btn" onClick={onPin}>
+          Закрепить
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function buildItem(
+  route: RouteSegment[],
+  cityIndex: Record<string, { x: number; y: number; label?: string }>
+) {
+  let d = 0;
+  for (const seg of route) {
+    if (seg.transfer) continue;
+    const a = cityIndex[seg.from];
+    const b = cityIndex[seg.to];
+    if (a && b) d += distance(a, b);
+  }
+  const transfers = route.filter((s) => s.transfer).length;
+  const start = cityIndex[route[0].from]?.label || route[0].from;
+  const end =
+    cityIndex[route[route.length - 1].to]?.label ||
+    route[route.length - 1].to;
+  return { route, dist: Math.round(d), transfers, start, end };
+}
+
+export default function SearchResults({
+  results,
+  bundle,
+  selected,
+  onShow,
+  onPin,
+}: Props) {
+  const cityIndex = useCityIndex(bundle);
+
+  const columns: { key: keyof SearchResults; title: string }[] = [
+    { key: 'exact', title: 'Точный поиск' },
+    { key: 'geo', title: 'Геозона' },
+    { key: 'bfs', title: 'BFS' },
+  ];
+
+  return (
+    <div
+      style={{
+        position: 'fixed',
+        right: 12,
+        bottom: 12,
+        display: 'flex',
+        gap: 8,
+        zIndex: 4,
+        fontFamily: 'Inter, system-ui, sans-serif',
+        color: 'var(--text)',
+      }}
+    >
+      {columns.map((col) => {
+        const items = results[col.key].map((r) => buildItem(r, cityIndex));
+        return (
+          <div key={col.key} style={{ width: 240, maxHeight: 360, overflowY: 'auto' }}>
+            <div className="font-semibold mb-2">{col.title}</div>
+            {items.map((item, idx) => (
+              <RouteCard
+                key={idx}
+                item={item}
+                active={
+                  selected?.type === col.key && selected.idx === idx
+                }
+                onShow={() => onShow(col.key, idx)}
+                onPin={() => onPin(col.key, idx)}
+              />
+            ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/lib/graph.ts
+++ b/src/lib/graph.ts
@@ -306,6 +306,97 @@ export function findRoute(
   return findRoutes(bundle, startId, endId, 1)[0] ?? [];
 }
 
+// Utility: filter routes by max transfers
+function filterByTransfers(routes: RouteSegment[][], maxTransfers: number) {
+  if (!isFinite(maxTransfers)) return routes;
+  return routes.filter(
+    (r) => r.filter((s) => s.transfer).length <= maxTransfers
+  );
+}
+
+// Helper to determine corridors passing through a city
+function corridorsOfCity(bundle: DataBundle, cityId: string): Set<string> {
+  const lineIds = new Set(
+    bundle.linePaths.filter((p) => p.city_id === cityId).map((p) => p.line_id)
+  );
+  const corridors = new Set<string>();
+  for (const l of bundle.lines) {
+    if (lineIds.has(l.line_id)) corridors.add(l.corridor_id);
+  }
+  return corridors;
+}
+
+// Restrict bundle to a single corridor
+function bundleForCorridor(bundle: DataBundle, corridorId: string): DataBundle {
+  const lines = bundle.lines.filter((l) => l.corridor_id === corridorId);
+  const lineSet = new Set(lines.map((l) => l.line_id));
+  const linePaths = bundle.linePaths.filter((p) => lineSet.has(p.line_id));
+  return { ...bundle, lines, linePaths };
+}
+
+// Геозонный поиск: маршруты в общих коридорах
+export function findRoutesGeozone(
+  bundle: DataBundle,
+  startId: string,
+  endId: string,
+  maxTransfers = Infinity,
+  k = 3
+): RouteSegment[][] {
+  const startCorr = corridorsOfCity(bundle, startId);
+  const endCorr = corridorsOfCity(bundle, endId);
+  const common = Array.from(startCorr).filter((c) => endCorr.has(c));
+  const out: RouteSegment[][] = [];
+  for (const c of common) {
+    const sub = bundleForCorridor(bundle, c);
+    const routes = filterByTransfers(findRoutes(sub, startId, endId, k), maxTransfers);
+    out.push(...routes);
+  }
+  return out;
+}
+
+// Поиск BFS без весов
+export function findRoutesBFS(
+  bundle: DataBundle,
+  startId: string,
+  endId: string,
+  maxTransfers = Infinity
+): RouteSegment[][] {
+  if (startId === endId) return [];
+  const { graph, cityLines } = buildWeightedGraph(bundle);
+  const startLines = cityLines.get(startId);
+  const endLines = cityLines.get(endId);
+  if (!startLines || !endLines) return [];
+
+  const startNodes = Array.from(startLines, (l) => nodeKey(startId, l));
+  const endNodes = new Set(Array.from(endLines, (l) => nodeKey(endId, l)));
+
+  const queue: Array<{ node: string; path: string[]; transfers: number }> = [];
+  for (const n of startNodes) queue.push({ node: n, path: [n], transfers: 0 });
+  const seen = new Set(startNodes);
+
+  while (queue.length) {
+    const cur = queue.shift()!;
+    if (endNodes.has(cur.node)) {
+      const route = buildSegmentsFromPath(cur.path, bundle);
+      return filterByTransfers([route], maxTransfers);
+    }
+    const neighbors = graph.get(cur.node) || [];
+    for (const { to, cost } of neighbors) {
+      const nextTransfers = cur.transfers + cost.transfers;
+      if (nextTransfers > maxTransfers) continue;
+      if (!seen.has(to)) {
+        seen.add(to);
+        queue.push({
+          node: to,
+          path: [...cur.path, to],
+          transfers: nextTransfers,
+        });
+      }
+    }
+  }
+  return [];
+}
+
 // очень простой раскладчик подписей (без коллизий, но с оффсетами)
 export function placeLabels(
   pts: Record<string, { x: number; y: number }>


### PR DESCRIPTION
## Summary
- Support exact, geozone and BFS route searches with transfer limits
- Show grouped results with show-path and pin controls
- Allow map to fit selected route

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5416fc8748321b49994ee85c6c096