### PR TITLE
feat: guard route analysis logging

### DIFF
--- a/src/components/MetroCanvas.tsx
+++ b/src/components/MetroCanvas.tsx
@@ -8,6 +8,10 @@ import { METRO_CONFIG } from '@/lib/metro-config';
 import { analyzeRoutes, createUnifiedSegments } from '@/lib/route-analyzer';
 import type { RouteSegment } from '@/lib/router';
 
+const DEBUG_ROUTE_ANALYSIS =
+  process.env.NODE_ENV !== 'production' &&
+  process.env.NEXT_PUBLIC_DEBUG_ROUTE_ANALYSIS === 'true';
+
 type Props = {
   bundle: DataBundle;
   activeLines: Set<string>;
@@ -21,6 +25,8 @@ export default function MetroCanvas({
 }: Props) {
   // Анализируем маршруты для выделения общих участков (для отладки)
   useEffect(() => {
+    if (!DEBUG_ROUTE_ANALYSIS) return;
+
     const analysis = analyzeRoutes(bundle.lines, bundle.linePaths, bundle.cities);
     console.log('📊 Анализ маршрутов:');
     console.log(`  Основные ветки: ${analysis.mainBranches.length}`);


### PR DESCRIPTION
## Summary
- add build-time DEBUG_ROUTE_ANALYSIS flag and only run route analyzer in debug builds

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c54deaba308321b57a2e078834d680