### PR TITLE
Handle hyphenated city names in driver city parsing

### DIFF
--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -73,7 +73,10 @@ function toDrivers(rows: Record<string, string>[], grid: CityGrid): Driver[] {
       .map((v) => normalizeToken(v))
       .filter(Boolean)
       .map((v) => ({
-        city_ids: v.split('-').map((c) => mapCity(c, grid)),
+        city_ids: v
+          .split(/\s-\s/)
+          .map((c) => mapCity(c.trim(), grid))
+          .filter(Boolean),
       }));
     return { name, variants } as Driver;
   });


### PR DESCRIPTION
## Summary
- ensure driver route parsing splits on hyphens surrounded by spaces, keeping internal hyphens in city names
- trim and filter city tokens before mapping to IDs to avoid bogus warnings for cities like Улан-Удэ and Санкт-Петербург

## Testing
- `npx ts-node -e "import { loadData } from './src/lib/csv'; import fs from 'fs/promises'; globalThis.fetch = async (url: string) => { const text = await fs.readFile('public' + url, 'utf8'); return new Response(text, { status: 200 }); }; (async () => { await loadData(); })();" 2>&1 | rg 'Unknown city: (Улан-Удэ|Санкт-Петербург)'`
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c5660e18f08321bb030684012cbcb7