### PR TITLE
Handle NaN driver cities silently

### DIFF
--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -66,7 +66,8 @@ function toCityGrid(rows: Record<string, string>[]): CityGrid {
 
 function mapCity(name: string, grid: CityGrid): string | undefined {
   const norm = normalizeToken(name);
-  const alias = CITY_ALIASES[norm] ?? norm;
+  if (norm.toLowerCase() === 'nan') return undefined;
+  const alias = CITY_ALIASES[norm.toLowerCase()] ?? norm;
   return grid[alias];
 }
 


### PR DESCRIPTION
## Summary
- Skip driver city tokens normalized to `nan` so they don't log or produce IDs

## Testing
- `npm test`
- `npx ts-node -O '{"module":"commonjs"}' -e "const { loadData } = require('./src/lib/csv'); const fs = require('fs').promises; global.fetch = (async (url: string) => ({ ok: true, status: 200, text: () => fs.readFile('public'+url, 'utf8') })) as any; loadData().then(()=> console.log('done')).catch((e:any)=>console.error(e));"`

------
https://chatgpt.com/codex/tasks/task_e_68c5698952248321bcafc42cac1d9cc3