### PR TITLE
Initialize driver index after CSV load

### DIFF
--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -9,6 +9,7 @@ import type {
   CityGrid,
 } from './types';
 import Papa from 'papaparse';
+export { initDriverIndex } from './driver-index';
 
 async function fetchText(url: string): Promise<string> {
   const res = await fetch(url, { cache: 'no-store' });


### PR DESCRIPTION
## Summary
- re-export initDriverIndex from csv utilities
- build driver index once CSV data loads and handle errors
- render map without index and show index init status bar

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c56f6da04c8321aeab58e3e5699afe