### PR TITLE
Add responsive route search and mobile zoom controls

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -15,6 +15,7 @@ html, body {
   --btn-border: #cccccc;
   --btn-hover-bg: #f2f2f2;
   --btn-hover-border: #999999;
+  --muted-text: rgba(17, 17, 17, 0.7);
 }
 
 html.dark {
@@ -26,6 +27,7 @@ html.dark {
   --btn-border: #3a3a3a;
   --btn-hover-bg: #3a3a3a;
   --btn-hover-border: #555555;
+  --muted-text: rgba(245, 245, 245, 0.7);
 }
 
 body {
@@ -45,6 +47,184 @@ body {
   box-shadow: 0 4px 24px rgba(0,0,0,.06);
   overflow: hidden;
   z-index: 1;
+}
+
+.legend {
+  position: fixed;
+  left: 12px;
+  top: 12px;
+  width: 320px;
+  max-height: calc(100vh - 24px);
+  overflow: auto;
+  background: var(--frame-bg);
+  border: 1px solid var(--frame-border);
+  border-radius: 12px;
+  box-shadow: 0 4px 24px rgba(0,0,0,.08);
+  padding: 16px;
+  z-index: 3;
+  color: var(--text);
+  font-family: 'Inter, system-ui, sans-serif';
+  backdrop-filter: blur(8px);
+}
+
+.legend::-webkit-scrollbar {
+  width: 6px;
+}
+
+.legend::-webkit-scrollbar-thumb {
+  background: rgba(0, 0, 0, 0.15);
+  border-radius: 999px;
+}
+
+.search-panel {
+  position: fixed;
+  top: 12px;
+  right: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 320px;
+  padding: 16px;
+  background: var(--frame-bg);
+  border: 1px solid var(--frame-border);
+  border-radius: 12px;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.12);
+  z-index: 5;
+  font-family: 'Inter, system-ui, sans-serif';
+  color: var(--text);
+  backdrop-filter: blur(8px);
+}
+
+.search-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.search-panel__title {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.search-panel__clear {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text);
+  font-size: 20px;
+  line-height: 1;
+  cursor: pointer;
+  display: grid;
+  place-items: center;
+  transition: background 150ms ease, border-color 150ms ease;
+}
+
+.search-panel__clear:hover,
+.search-panel__clear:focus-visible {
+  background: var(--btn-hover-bg);
+  border-color: var(--btn-hover-border);
+  outline: none;
+}
+
+.search-panel__form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.search-panel__inputs {
+  display: flex;
+  gap: 12px;
+}
+
+.search-panel__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  flex: 1;
+}
+
+.search-panel__label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--muted-text);
+}
+
+.search-panel__select {
+  width: 100%;
+  min-height: 40px;
+  padding: 0 10px;
+  border-radius: 8px;
+  border: 1px solid var(--btn-border);
+  background: var(--btn-bg);
+  color: var(--text);
+  font: 500 14px/1.2 'Inter', system-ui, sans-serif;
+  box-shadow: inset 0 1px 2px rgba(0,0,0,0.05);
+  transition: border-color 150ms ease, box-shadow 150ms ease;
+}
+
+.search-panel__select:focus {
+  outline: none;
+  border-color: var(--btn-hover-border);
+  box-shadow: 0 0 0 3px rgba(37, 99, 235, 0.15);
+}
+
+.search-panel__submit {
+  width: 100%;
+  justify-content: center;
+}
+
+.search-panel__summary {
+  font-size: 13px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  background: rgba(37, 99, 235, 0.12);
+  border: 1px solid rgba(37, 99, 235, 0.22);
+  color: var(--text);
+}
+
+.search-panel__error {
+  font-size: 13px;
+  color: #dc2626;
+}
+
+.zoom-controls {
+  position: fixed;
+  right: 12px;
+  bottom: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  z-index: 4;
+}
+
+.zoom-controls__btn {
+  width: 44px;
+  height: 44px;
+  border: 1px solid var(--btn-border);
+  border-radius: 12px;
+  background: var(--btn-bg);
+  color: var(--text);
+  font-size: 24px;
+  font-weight: 600;
+  line-height: 1;
+  cursor: pointer;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  transition: background 150ms ease, border-color 150ms ease, transform 120ms ease;
+}
+
+.zoom-controls__btn:hover {
+  background: var(--btn-hover-bg);
+  border-color: var(--btn-hover-border);
+}
+
+.zoom-controls__btn:active {
+  transform: translateY(1px);
 }
 .map-btn {
   height: 36px;
@@ -69,7 +249,7 @@ body {
   box-shadow: 0 1px 2px rgba(0,0,0,0.1);
 }
 
-.map-svg {
+.map-svg { 
   width: 100%;
   height: 100%;
   display: block;
@@ -107,4 +287,59 @@ body {
 .map-svg circle:hover {
   stroke-width: 1.6px;
   stroke: #333;
+}
+
+@media (max-width: 1024px) {
+  .legend {
+    width: 280px;
+  }
+
+  .search-panel {
+    width: 280px;
+  }
+}
+
+@media (max-width: 768px) {
+  .map-frame {
+    inset: 0;
+    border-radius: 0;
+  }
+
+  .legend {
+    left: 50%;
+    top: auto;
+    bottom: 110px;
+    transform: translateX(-50%);
+    width: calc(100vw - 24px);
+    max-height: 45vh;
+    padding: 12px;
+  }
+
+  .search-panel {
+    left: 12px;
+    right: 12px;
+    top: 12px;
+    width: auto;
+    padding: 12px;
+  }
+
+  .search-panel__inputs {
+    flex-direction: column;
+  }
+
+  .search-panel__submit {
+    width: 100%;
+  }
+
+  .zoom-controls {
+    flex-direction: row;
+    right: 12px;
+    bottom: 12px;
+  }
+
+  .zoom-controls__btn {
+    width: 48px;
+    height: 48px;
+    font-size: 22px;
+  }
 }

--- a/src/components/Legend.tsx
+++ b/src/components/Legend.tsx
@@ -58,24 +58,7 @@ export default function Legend({ bundle, activeLines, onToggle, onToggleMany, on
   };
 
   return (
-    <div
-      style={{
-        position: 'fixed',
-        left: 12,
-        top: 12,
-        width: 320,
-        maxHeight: 'calc(100vh - 24px)',
-        overflow: 'auto',
-        background: 'var(--frame-bg)',
-        border: '1px solid var(--frame-border)',
-        borderRadius: 12,
-        boxShadow: '0 4px 24px rgba(0,0,0,.06)',
-        padding: 16,
-        zIndex: 3,
-        fontFamily: 'Inter, system-ui, sans-serif',
-        color: 'var(--text)',
-      }}
-    >
+    <div className="legend">
       <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 16 }}>
         <h3 style={{ margin: 0, fontSize: 16, fontWeight: 600, color: 'var(--text)' }}>Коридоры и линии</h3>
       </div>

--- a/src/components/SearchPanel.tsx
+++ b/src/components/SearchPanel.tsx
@@ -1,0 +1,160 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import type { DataBundle } from '@/lib/types';
+import type { RouteSegment } from '@/lib/router';
+import { findRoute } from '@/lib/graph';
+
+interface Props {
+  bundle: DataBundle;
+  onRouteSelect: (route: RouteSegment[], cityPath: string[]) => void;
+  onReset: () => void;
+  hasRoute: boolean;
+}
+
+function buildCityPath(route: RouteSegment[]): string[] {
+  const path: string[] = [];
+  for (const segment of route) {
+    if (segment.transfer) continue;
+    if (path.length === 0) {
+      path.push(segment.from);
+    } else if (path[path.length - 1] !== segment.from) {
+      path.push(segment.from);
+    }
+    path.push(segment.to);
+  }
+  return path;
+}
+
+export default function SearchPanel({ bundle, onRouteSelect, onReset, hasRoute }: Props) {
+  const [from, setFrom] = useState('');
+  const [to, setTo] = useState('');
+  const [error, setError] = useState('');
+  const [summary, setSummary] = useState('');
+
+  useEffect(() => {
+    if (!hasRoute) {
+      setSummary('');
+    }
+  }, [hasRoute]);
+
+
+  const cityOptions = useMemo(() => {
+    return [...bundle.cities].sort((a, b) => {
+      const aLabel = a.label || a.city_id;
+      const bLabel = b.label || b.city_id;
+      return aLabel.localeCompare(bLabel, 'ru');
+    });
+  }, [bundle.cities]);
+
+  const labelById = useMemo(() => {
+    const map = new Map<string, string>();
+    bundle.cities.forEach((city) => {
+      map.set(city.city_id, city.label || city.city_id);
+    });
+    return map;
+  }, [bundle.cities]);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!from || !to) {
+      setError('Выберите станции отправления и назначения.');
+      return;
+    }
+    if (from === to) {
+      setError('Выберите разные станции.');
+      return;
+    }
+
+    const route = findRoute(bundle, from, to);
+    if (!route.length) {
+      setError('Маршрут не найден. Попробуйте выбрать другие станции.');
+      return;
+    }
+
+    const cityPath = buildCityPath(route);
+    onRouteSelect(route, cityPath);
+    setSummary(`${labelById.get(from) ?? from} → ${labelById.get(to) ?? to}`);
+    setError('');
+  };
+
+  const handleReset = () => {
+    setFrom('');
+    setTo('');
+    setError('');
+    setSummary('');
+    onReset();
+  };
+
+  const showResetButton = hasRoute || Boolean(from || to || summary);
+
+  return (
+    <aside className="search-panel">
+      <div className="search-panel__header">
+        <h2 className="search-panel__title">Поиск маршрута</h2>
+        {showResetButton && (
+          <button
+            type="button"
+            className="search-panel__clear"
+            onClick={handleReset}
+            aria-label="Сбросить поиск"
+          >
+            ×
+          </button>
+        )}
+      </div>
+
+      <form className="search-panel__form" onSubmit={handleSubmit}>
+        <div className="search-panel__inputs">
+          <label className="search-panel__field">
+            <span className="search-panel__label">Откуда</span>
+            <select
+              value={from}
+              onChange={(e) => {
+                setFrom(e.target.value);
+                if (error) setError('');
+              }}
+              className="search-panel__select"
+            >
+              <option value="">Выберите станцию</option>
+              {cityOptions.map((city) => (
+                <option key={city.city_id} value={city.city_id}>
+                  {city.label || city.city_id}
+                </option>
+              ))}
+            </select>
+          </label>
+
+          <label className="search-panel__field">
+            <span className="search-panel__label">Куда</span>
+            <select
+              value={to}
+              onChange={(e) => {
+                setTo(e.target.value);
+                if (error) setError('');
+              }}
+              className="search-panel__select"
+            >
+              <option value="">Выберите станцию</option>
+              {cityOptions.map((city) => (
+                <option key={`${city.city_id}-to`} value={city.city_id}>
+                  {city.label || city.city_id}
+                </option>
+              ))}
+            </select>
+          </label>
+        </div>
+
+        <button type="submit" className="map-btn search-panel__submit">
+          Найти
+        </button>
+      </form>
+
+      {summary && !error && (
+        <div className="search-panel__summary">Маршрут: {summary}</div>
+      )}
+
+      {error && <div className="search-panel__error">{error}</div>}
+    </aside>
+  );
+}


### PR DESCRIPTION
## Summary
- replace the old drawer with a fixed search panel for selecting origin and destination stations, highlighting the requested route and providing a reset action
- expose zoom controls and a reset method from the metro canvas so touch users can zoom in/out and restore the view, and automatically dim non-route lines when a route is active
- refresh the legend and global styles to support mobile layouts, including responsive spacing, zoom buttons, and typography tweaks

## Testing
- npm run lint *(warnings only from existing geometry and route-analyzer files)*

------
https://chatgpt.com/codex/tasks/task_e_68e128c187548321b2dac90eb97a76ff